### PR TITLE
Retry subclasses of retryable exceptions

### DIFF
--- a/spec/variable_retry_strategy_spec.rb
+++ b/spec/variable_retry_strategy_spec.rb
@@ -35,7 +35,7 @@ describe "variable retry strategy" do
         class JobB < Que::Job
           include Que::Failure::VariableRetry
 
-          retryable_exceptions [Exception]
+          retryable_exceptions [RuntimeError]
 
           def run
             raise StandardError.new('I broke.')
@@ -54,13 +54,15 @@ describe "variable retry strategy" do
 
     describe "with no retry intervals have been set" do
       it "fails the job" do
+        class MyError < StandardError; end
+
         class JobC < Que::Job
           include Que::Failure::VariableRetry
 
           retryable_exceptions [StandardError]
 
           def run
-            raise StandardError.new('I broke.')
+            raise MyError.new('I broke.')
           end
         end
 


### PR DESCRIPTION
@barisbalic this is how gocardless/activejob-retry works, and I think it's quite nice. Means you can just retry `SystemCallError` instead of `Errno::ETIMEOUT` and all its brothers and sisters. I can't get rspec to run at all locally - do we have CI on this repo?