### PR TITLE
Fail job if "after final retry callback" fails

### DIFF
--- a/lib/que/failure/strategies/variable_retry.rb
+++ b/lib/que/failure/strategies/variable_retry.rb
@@ -34,12 +34,15 @@ module Que
             if delay
               Que.execute :set_error, [count, delay, message] + job.values_at(:queue, :priority, :run_at, :job_id)
             else
-              @after_final_retry_callback.call(error, job) if @after_final_retry_callback
-
               if @destroy_after_final_retry
                 Que.execute :destroy_job, job.values_at(:queue, :priority, :run_at, :job_id)
               else
                 Que.execute :fail_job, [count, message] + job.values_at(:queue, :priority, :run_at, :job_id)
+              end
+
+              @after_final_retry_callback.call(error, job) if @after_final_retry_callback
+
+              unless @destroy_after_final_retry
                 Que::Failure.unhandled_failure(error, job)
               end
             end

--- a/spec/variable_retry_strategy_spec.rb
+++ b/spec/variable_retry_strategy_spec.rb
@@ -187,6 +187,10 @@ describe "variable retry strategy" do
       JobG.enqueue :priority => 89
       Que::Job.work
       job = DB[:que_jobs].first
+      job[:error_count].should == 1
+      job[:retryable].should == false
+      t = (Time.now ).to_f.round(6)
+      job[:failed_at].to_f.round(6).should be_within(1.5).of(t + 1.0)
       $catastrophy.should == true
     end
   end


### PR DESCRIPTION
We've seen a problem where there was an exception in the `after_final_retry` callback.  In this situation, the job doesn't get marked as failed, so it can potentially be retried forever.

This PR reorders the failure handling so that the job is first marked as failed (or destroyed), before the callbacks run.  Having the user-defined callbacks run last makes sense as there is potentially more that can go wrong there, so best to make the job safe first.

@Sinjo, how does this look?