### PR TITLE
Add retryable failure callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ Que::Failure.on_unhandled_failure do |error, job|
 end
 ```
 
+### Setting the retryable failure callback
+
+This callback will be invoked whenever a job fails but will be retried.
+
+```ruby
+Que::Failure.on_retryable_failure do |error, job|
+  warn("Error running job - will be retried: #{error.full_message}")
+end
+```
+
 ### Additional queries
 
 For convenience there are some canned statements that Que provides, for example:

--- a/lib/que/failure.rb
+++ b/lib/que/failure.rb
@@ -12,10 +12,21 @@ module Que
         @unhandled_failure_callback = callback
       end
 
+      def on_retryable_failure(&callback)
+        @retryable_failure_callback = callback
+      end
+
       def unhandled_failure(error, job)
         return unless @unhandled_failure_callback
 
         @unhandled_failure_callback.call(error, job)
+      rescue
+      end
+
+      def retryable_failure(error, job)
+        return unless @retryable_failure_callback
+
+        @retryable_failure_callback.call(error, job)
       rescue
       end
     end

--- a/lib/que/failure/strategies/variable_retry.rb
+++ b/lib/que/failure/strategies/variable_retry.rb
@@ -33,6 +33,7 @@ module Que
 
             if delay
               Que.execute :set_error, [count, delay, message] + job.values_at(:queue, :priority, :run_at, :job_id)
+              Que::Failure.retryable_failure(error, job)
             else
               @after_final_retry_callback.call(error, job) if @after_final_retry_callback
 


### PR DESCRIPTION
Adds a callback that will be invoked when a job fails but will be retried.  The intention for this is to log when this happens, so that we have some record of all failures.

@Sinjo, please could you review?