### PR TITLE
Allow callable retry intervals

### DIFF
--- a/lib/que/failure/strategies/variable_retry.rb
+++ b/lib/que/failure/strategies/variable_retry.rb
@@ -30,6 +30,7 @@ module Que
 
           if retryable_exception?(error)
             delay = @retry_intervals && @retry_intervals[count - 1]
+            delay = delay.call if delay.respond_to(:call)
 
             if delay
               Que.execute :set_error, [count, delay, message] + job.values_at(:queue, :priority, :run_at, :job_id)


### PR DESCRIPTION
Useful if you want to add randomness to your retry intervals (e.g., to avoid a thundering herd).